### PR TITLE
Add --coverage to pkg.script.test if coveralls is selected

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -15,7 +15,7 @@ describe('generator-jest:app', () => {
       .then(() => {
         assert.jsonFileContent('package.json', {
           scripts: {
-            test: 'jest'
+            test: 'jest --coverage'
           },
           devDependencies: {
             jest: rootPkg.devDependencies.jest,
@@ -28,11 +28,11 @@ describe('generator-jest:app', () => {
   it('generates for node', () => {
     return helpers
       .run(jestGenerator)
-      .withPrompts({ testEnvironment: 'node', coveralls: false })
+      .withPrompts({ testEnvironment: 'node' })
       .then(() => {
         assert.jsonFileContent('package.json', {
           scripts: {
-            test: 'jest'
+            test: 'jest --coverage'
           },
           devDependencies: {
             jest: rootPkg.devDependencies.jest,
@@ -61,7 +61,7 @@ describe('generator-jest:app', () => {
   it('is non-destructive of current scripts', () => {
     return helpers
       .run(jestGenerator)
-      .withPrompts({ testEnvironment: 'node', coveralls: false })
+      .withPrompts({ testEnvironment: 'node' })
       .inTmpDir(() => {
         fs.writeFileSync(
           'package.json',
@@ -75,7 +75,7 @@ describe('generator-jest:app', () => {
       .then(() => {
         assert.jsonFileContent('package.json', {
           scripts: {
-            test: 'eslint && jest'
+            test: 'eslint && jest --coverage'
           }
         });
       });
@@ -122,35 +122,14 @@ describe('generator-jest:app', () => {
       .run(jestGenerator)
       .withOptions({ coveralls: false })
       .then(() => {
+        assert.jsonFileContent('package.json', {
+          scripts: {
+            test: 'jest'
+          }
+        });
         assert.noJsonFileContent('package.json', {
           scripts: {
             posttest: 'cat ./coverage/lcov.info | coveralls'
-          }
-        });
-      });
-  });
-
-  it('adds --coverage parameter for non-jsdom environments', () => {
-    return helpers
-      .run(jestGenerator)
-      .withPrompts({ coveralls: true, testEnvironment: 'node' })
-      .then(() => {
-        assert.jsonFileContent('package.json', {
-          scripts: {
-            test: 'jest --coverage'
-          }
-        });
-      });
-  });
-
-  it('doesnt add --coverage parameter for non-jsdom environments', () => {
-    return helpers
-      .run(jestGenerator)
-      .withPrompts({ coveralls: false, testEnvironment: 'node' })
-      .then(() => {
-        assert.noJsonFileContent('package.json', {
-          scripts: {
-            test: 'jest --coverage'
           }
         });
       });

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -28,7 +28,7 @@ describe('generator-jest:app', () => {
   it('generates for node', () => {
     return helpers
       .run(jestGenerator)
-      .withPrompts({ testEnvironment: 'node' })
+      .withPrompts({ testEnvironment: 'node', coveralls: false })
       .then(() => {
         assert.jsonFileContent('package.json', {
           scripts: {
@@ -61,7 +61,7 @@ describe('generator-jest:app', () => {
   it('is non-destructive of current scripts', () => {
     return helpers
       .run(jestGenerator)
-      .withPrompts({ testEnvironment: 'node' })
+      .withPrompts({ testEnvironment: 'node', coveralls: false })
       .inTmpDir(() => {
         fs.writeFileSync(
           'package.json',
@@ -125,6 +125,32 @@ describe('generator-jest:app', () => {
         assert.noJsonFileContent('package.json', {
           scripts: {
             posttest: 'cat ./coverage/lcov.info | coveralls'
+          }
+        });
+      });
+  });
+
+  it('adds --coverage parameter for non-jsdom environments', () => {
+    return helpers
+      .run(jestGenerator)
+      .withPrompts({ coveralls: true, testEnvironment: 'node' })
+      .then(() => {
+        assert.jsonFileContent('package.json', {
+          scripts: {
+            test: 'jest --coverage'
+          }
+        });
+      });
+  });
+
+  it('doesnt add --coverage parameter for non-jsdom environments', () => {
+    return helpers
+      .run(jestGenerator)
+      .withPrompts({ coveralls: false, testEnvironment: 'node' })
+      .then(() => {
+        assert.noJsonFileContent('package.json', {
+          scripts: {
+            test: 'jest --coverage'
           }
         });
       });

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -70,7 +70,11 @@ module.exports = class extends Generator {
       .map(str => str.trim())
       .filter(Boolean);
     if (!testScripts.find(script => script.startsWith('jest'))) {
-      testScripts.push('jest');
+      testScripts.push(
+        this.props.coveralls && this.props.testEnvironment !== 'jsdom'
+          ? 'jest --coverage'
+          : 'jest'
+      );
       pkg.scripts.test = testScripts.join(' && ');
     }
 

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -56,10 +56,6 @@ module.exports = class extends Generator {
       devDependencies: {
         jest: rootPkg.devDependencies.jest,
         'jest-cli': rootPkg.devDependencies['jest-cli']
-      },
-      jest: {
-        collectCoverage: true,
-        coverageDirectory: 'coverage'
       }
     });
 
@@ -70,11 +66,7 @@ module.exports = class extends Generator {
       .map(str => str.trim())
       .filter(Boolean);
     if (!testScripts.find(script => script.startsWith('jest'))) {
-      testScripts.push(
-        this.props.coveralls && this.props.testEnvironment !== 'jsdom'
-          ? 'jest --coverage'
-          : 'jest'
-      );
+      testScripts.push(this.props.coveralls ? 'jest --coverage' : 'jest');
       pkg.scripts.test = testScripts.join(' && ');
     }
 
@@ -85,8 +77,9 @@ module.exports = class extends Generator {
     }
 
     if (this.props.testEnvironment !== 'jsdom') {
-      pkg.jest = {};
-      pkg.jest.testEnvironment = this.props.testEnvironment;
+      pkg.jest = {
+        testEnvironment: this.props.testEnvironment
+      };
     }
 
     this.fs.writeJSON(this.destinationPath('package.json'), pkg);


### PR DESCRIPTION
In case jsdom is the environment [jest is configured to show coverage results](https://github.com/SBoudrias/generator-jest/blob/53d94f57c5bbc1ca6db50c0809a88ddc1da30d1d/generators/app/index.js#L60) but for`testEnvironmnet: node` you need to manually add `--coverage` in the `test` script of the `package.json` file because [the jest configuration is cleaned up](https://github.com/SBoudrias/generator-jest/blob/53d94f57c5bbc1ca6db50c0809a88ddc1da30d1d/generators/app/index.js#L83).

I've added [a fix](https://github.com/MarcoScabbiolo/generator-jest/blob/9d2cf2b0c83f5019743916739140b46d4a1bdcfe/generators/app/index.js#L74) to add the `--coverage` parameter if the `testEnvironment` is `node` and `coveralls` is enabled.


Had to do some changes to the already existing tests because the `coveralls` prompt doesn't have a default value and inquirer [sets it to true by default](https://github.com/SBoudrias/Inquirer.js/blob/9135e38fe67fd1afa0d6efd99f2e8ca788d69c11/lib/prompts/confirm.js#L15), so I had to set `coveralls` to `false` in some tests. I've added two tests for the new behaviour.